### PR TITLE
fix: add force refresh option

### DIFF
--- a/.github/workflows/erlang.yml
+++ b/.github/workflows/erlang.yml
@@ -10,7 +10,7 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2.0.0
-    - uses: gleam-lang/setup-erlang@v1.1.0
+    - uses: gleam-lang/setup-erlang@v1.1.2
       with:
         otp-version: 23.2
     - name: Compile
@@ -28,8 +28,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2.0.0
-    - uses: gleam-lang/setup-erlang@v1.1.0
+    - uses: gleam-lang/setup-erlang@v1.1.2
       with:
-        otp-version: 22.1
+        otp-version: 23.2
     - name: Run dialyzer
       run: make dialyze

--- a/src/id_token.erl
+++ b/src/id_token.erl
@@ -16,7 +16,8 @@ validate(Provider, IdToken) ->
     true  ->
       case id_token_jws:validate(IdToken, Keys) of
         {error, no_public_key_matches} ->
-          refresh_and_validate(Provider, IdToken);
+          refresh_and_validate(Provider, IdToken,
+                               #{force_refresh => true});
         Result ->
           Result
       end;
@@ -31,7 +32,11 @@ sign(Alg, Claims) ->
   end.
 
 refresh_and_validate(Provider, IdToken) ->
-  #{keys := FreshKeys} = id_token_provider:refresh_keys(Provider),
+  refresh_and_validate(Provider, IdToken, #{}).
+
+refresh_and_validate(Provider, IdToken, Opts) ->
+  #{keys := FreshKeys} =
+    id_token_provider:refresh_keys(Provider, Opts),
   id_token_jws:validate(IdToken, FreshKeys).
 
 %%%_* Emacs ============================================================


### PR DESCRIPTION
If we fail to validate a token because we do now have the correct key in our cache, i.e. `{error, no_public_key_matches}`, then we want to force refresh the public keys of the provider regardless if we have a cached entry or not. This is currently not the behaviour which does not make sense. The default behaviour is to only refresh keys from a provider if we don't already have a cached entry, however, if the cached entry does not contain the correct keys then we want to force an update, regardless if we already have a cached cache entry.

The old behaviour is leading to problems in the tests in kivra_core, which is why I started investigating this.