### PR TITLE
fix: Shorten revalidate cycle for failed validation

### DIFF
--- a/src/id_token_provider.erl
+++ b/src/id_token_provider.erl
@@ -76,8 +76,8 @@ handle_info({refresh, Provider}, State) ->
         (RevalidateTime - Now) * 1000;
       false ->
         %% Not enough time for revalidation, let the first request pay
-        %% the price and re-initiate async_revalidate-loop after 60 seconds
-        60_000
+        %% the price and re-initiate async_revalidate-loop after 10 seconds
+        10_000
     end,
   timer:send_after(Delay, self(), {refresh, Provider}),
   {noreply, State}.


### PR DESCRIPTION
## About

If async revalidation is skipped due to insufficient time, initiate the next cycle after 10 seconds rather than 60 seconds to avoid situations where the cache expiration time is equal to the async revalidate time, which could lead to an endless cycle of unsuccessful async revalidation.