### PR TITLE
no-release: prefer a known runner version

### DIFF
--- a/.github/workflows/erlang.yml
+++ b/.github/workflows/erlang.yml
@@ -6,7 +6,7 @@ jobs:
 
   build_and_test:
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     name: OTP ${{matrix.otp}}
     strategy:
@@ -33,7 +33,7 @@ jobs:
   release:
     if: github.ref == 'refs/heads/master' && startsWith(github.event.head_commit.message, 'no-release:') == false
     needs: build_and_test
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
     - name: Bump version and push tag
       id: tag_version


### PR DESCRIPTION
Even if it's every 2 years, using `latest` is akin to using `main` for a branch reference.

We want to pin the runner version we're using.