### PR TITLE
no-release: Don't blame on recent formatting change

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,2 @@
+# Project-wide erlfmt formatting
+986b423d41f781c6935b15b5b44d3dc0b7a10ef4


### PR DESCRIPTION
## Motivation

Avoid blame on recent formatting changes.

## Description

Ease future blaming.

## Further considerations

I ran `git config --global blame.ignoreRevsFile .git-blame-ignore-revs` locally (not sure that that file name is "standard" - but it seems to be widely used -, so I copied it from `kivra-in-a-box`) to always ignore blame in a consistent way.