### PR TITLE
no-release(fix): workflow concurrent execution conditions

### DIFF
--- a/.github/workflows/erlang.yml
+++ b/.github/workflows/erlang.yml
@@ -2,6 +2,10 @@ name: Erlang CI
 
 on: [push]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/master' }}
+
 jobs:
 
   build_and_test:


### PR DESCRIPTION
> ⚠️ **Disclaimer** ⚠️ this is a Creative Friday initiative. A prior discussion around it might have not happened.

# Motivation

Prevent errors for subsequent "merges", e.g. you may want to validate a given CI before moving on to the next one.

# Description

I'm under the impression we want:

1. to not allow concurrency for feature branches by cancelling current runs
2. to not allow concurrency in release branches by making sure we run one workflow at a time

# Further considerations

An undesired consequence of this change is that releases will be done in sequence so the process might take longer. On the other hand, it's also less error prone.