### PR TITLE
Potential fix for code scanning alert no. 5: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/erlang.yml
+++ b/.github/workflows/erlang.yml
@@ -1,5 +1,8 @@
 ---
 name: ci
+permissions:
+  contents: write
+  packages: write
 
 on:
   # for feature branches and releases

--- a/.github/workflows/erlang.yml
+++ b/.github/workflows/erlang.yml
@@ -2,7 +2,6 @@
 name: ci
 permissions:
   contents: write
-  packages: write
 
 on:
   # for feature branches and releases


### PR DESCRIPTION
Potential fix for [https://github.com/kivra/id_token/security/code-scanning/5](https://github.com/kivra/id_token/security/code-scanning/5)

To fix the issue, we will add a `permissions` block at the root level of the workflow. This block will define the minimal permissions required for the workflow to function correctly. Based on the provided workflow, the following permissions are necessary:
- `contents: read` for accessing repository contents.
- `contents: write` for pushing changes to the repository (e.g., updating `rebar.lock`).
- `packages: write` for creating GitHub releases.

The `permissions` block will be added at the top of the workflow, just below the `name` field.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
