### PR TITLE
no-release(fix): be more relaxed for `no-release`

### DIFF
--- a/.github/workflows/erlang.yml
+++ b/.github/workflows/erlang.yml
@@ -75,7 +75,7 @@ jobs:
         GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
 
   release:
-    if: github.ref == 'refs/heads/master' && startsWith(github.event.head_commit.message, 'no-release:') == false
+    if: github.ref == 'refs/heads/master' && startsWith(github.event.head_commit.message, 'no-release') == false
     runs-on: ubuntu-24.04
     steps:
     - uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0


### PR DESCRIPTION
# Motivation

Ease cross-process/reasoning consistency.

# Description

`no-release` is not exactly Conventional Commits, but we sometimes wanna write a title like `no-release(fix/doc): ...` and still get not release. This move the needle in that sense.