### PR TITLE
no-release: do not update 'hackney' to v2

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -30,6 +30,10 @@
       ],
       "depNameTemplate": "{{{org}}}/{{{depName}}}{{#if prefix}}/{{{replace '/v$' '' prefix}}}{{/if}}",
       "extractVersionTemplate": "^{{{prefix}}}(?<version>.*$)"
+    },
+    {
+      "matchPackageNames": "hackney",
+      "allowedVersions": "< 2.0.0"
     }
   ]
 }


### PR DESCRIPTION
## Description

Hackney v2 has been released which contains some breaking changes (e.g. [here](https://github.com/kivra/id_token/pull/50)). Do not renovate for now