### PR TITLE
fix: [PTF-1954] use shared Renovate config (from `platform-ci`)

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,9 +1,6 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": [
-    "config:best-practices",
-    ":disableDigestUpdates"
-  ],
+  "extends": ["github>kivra/platform-ci//renovate/platform.json5#renovate/v1.0.0"],
   "packageRules": [
     {
       "matchPackageNames": "hackney",


### PR DESCRIPTION
# Motivation

Ease maintenance.

# Description

We start with a simple Renovate package that updates versions for 1. itself, 2. flake.nix.